### PR TITLE
bump PyQt5 version, previous not installing on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ lxml==4.9.4
 MarkupSafe==2.1.3
 oauthlib==3.2.2
 pycparser==2.21
-PyQt5==5.15.4
+PyQt5==5.15.10
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.13.0
 python-docx==0.8.11


### PR DESCRIPTION
Error on Windows when installing `requirements.txt` `PyQt5==5.15.4`:

```
Collecting PyQt5==5.15.4 (from -r .\requirements.txt (line 18))
  Using cached PyQt5-5.15.4.tar.gz (3.3 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [26 lines of output]
      pyproject.toml: line 7: using '[tool.sip.metadata]' to specify the project metadata is deprecated and will be removed in SIP v7.0.0, use '[project]' instead
```

Bumped to `5.15.10` resolved. Tested working on Ubuntu and Windows.